### PR TITLE
Add Sparkle updater framework

### DIFF
--- a/.github/prepRelease.sh
+++ b/.github/prepRelease.sh
@@ -1,0 +1,56 @@
+#!/bin/zsh
+cd $GITHUB_WORKSPACE
+eval $(grep -m 1 "MARKETING_VERSION" HeliPort.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
+
+echo "::set-env name=NewVer::$MARKETING_VERSION"
+
+# Unless this project becomes insane, there's no chance that the version number will be larger than 9.9.9
+# Don't bump version for tag since we're using keywords for releases (Drafts can't be overridden in GH Actions)
+#if [[ ${MARKETING_VERSION##*.} == 9 ]]; then
+#    if [[ ${MARKETING_VERSION:2:1} == 9 ]]; then
+#        NewVer="$((${MARKETING_VERSION:0:1}+1)).0.0"
+#    else
+#        NewVer="${MARKETING_VERSION:0:1}.$((${MARKETING_VERSION:2:1}+1)).0"
+#    fi
+#else
+#    NewVer="${MARKETING_VERSION%.*}.$((${MARKETING_VERSION##*.}+1))"
+#fi
+
+#cd build/Build/Products/Release
+cd build/Build/Products/Debug
+ditto -c -k --sequesterRsrc --keepParent *.app HeliPort.zip
+cd -
+mkdir Artifacts
+cp -R build/Build/Products/Debug/*.zip Artifacts
+
+git log -"20" --format="- %H %s" | grep -v 'gitignore\|Repo\|Docs\|Merge\|yml\|CI\|Commit\|commit\|attributes' | sed '/^$/d' >> ReleaseNotes.md
+#git log -"$(git rev-list --count $(git rev-list --tags | head -n 1)..HEAD)" --format="- %H %s" | grep -v 'gitignore\|Repo\|Docs\|Merge\|yml\|CI\|Commit\|commit\|attributes' | sed  '/^$/d' >> ReleaseNotes.md
+
+mkdir sparkle
+cd sparkle
+rawURL="https://github.com/sparkle-project/Sparkle/releases/latest"
+URL="https://github.com$(one=${"$(curl -L --silent "${rawURL}" | grep '/download/' | grep -m 1 'xz' )"#*href=\"} && two=${one%\"\ rel*} && echo $two)"
+curl -#LO "${URL}"
+tar xvf *.xz >/dev/null 2>&1
+cd ..
+
+TIME="$(date +"%a, %d %b %Y %T %z")"
+
+APPCAST=(
+    '<?xml version="1.0" standalone="yes"?>'
+    '<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">'
+    '    <channel>'
+    '        <title>HeliPort</title>'
+    '        <item>'
+    "            <title>${MARKETING_VERSION}</title>"
+    "            <pubDate>${TIME}</pubDate>"
+    "            <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>"
+    "            <enclosure url=\"https://github.com/zxystd/HeliPort/releases/latest/download/HeliPort.zip\" sparkle:version=\"${MARKETING_VERSION}\" sparkle:shortVersionString=\"${MARKETING_VERSION}\" type=\"application/octet-stream\" $(./sparkle/bin/sign_update -s ${SPARKLE_KEY} ./Artifacts/HeliPort.zip)/>"
+    '        </item>'
+    '    </channel>'
+    '</rss>'
+)
+
+for appcast in "${APPCAST[@]}"; do
+    echo "${appcast}" >> ./Artifacts/appcast.xml
+done

--- a/.github/prepRelease.sh
+++ b/.github/prepRelease.sh
@@ -18,18 +18,18 @@
 cd $GITHUB_WORKSPACE
 eval $(grep -m 1 "MARKETING_VERSION" HeliPort.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
 
-echo "::set-env name=NewVer::$MARKETING_VERSION"
+echo "::set-env name=NEWVER::$MARKETING_VERSION"
 
 # Unless this project becomes insane, there's no chance that the version number will be larger than 9.9.9
 # Don't bump version for tag since we're using keywords for releases (Drafts can't be overridden in GH Actions)
 #if [[ ${MARKETING_VERSION##*.} == 9 ]]; then
 #    if [[ ${MARKETING_VERSION:2:1} == 9 ]]; then
-#        NewVer="$((${MARKETING_VERSION:0:1}+1)).0.0"
+#        NEWVER="$((${MARKETING_VERSION:0:1}+1)).0.0"
 #    else
-#        NewVer="${MARKETING_VERSION:0:1}.$((${MARKETING_VERSION:2:1}+1)).0"
+#        NEWVER="${MARKETING_VERSION:0:1}.$((${MARKETING_VERSION:2:1}+1)).0"
 #    fi
 #else
-#    NewVer="${MARKETING_VERSION%.*}.$((${MARKETING_VERSION##*.}+1))"
+#    NEWVER="${MARKETING_VERSION%.*}.$((${MARKETING_VERSION##*.}+1))"
 #fi
 
 #cd build/Build/Products/Release
@@ -49,24 +49,3 @@ URL="https://github.com$(one=${"$(curl -L --silent "${rawURL}" | grep '/download
 curl -#LO "${URL}"
 tar xvf *.xz >/dev/null 2>&1
 cd ..
-
-TIME="$(date +"%a, %d %b %Y %T %z")"
-
-APPCAST=(
-    '<?xml version="1.0" standalone="yes"?>'
-    '<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">'
-    '    <channel>'
-    '        <title>HeliPort</title>'
-    '        <item>'
-    "            <title>${MARKETING_VERSION}</title>"
-    "            <pubDate>${TIME}</pubDate>"
-    "            <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>"
-    "            <enclosure url=\"https://github.com/zxystd/HeliPort/releases/latest/download/HeliPort.zip\" sparkle:version=\"${MARKETING_VERSION}\" sparkle:shortVersionString=\"${MARKETING_VERSION}\" type=\"application/octet-stream\" $(./sparkle/bin/sign_update -s ${SPARKLE_KEY} ./Artifacts/HeliPort.zip)/>"
-    '        </item>'
-    '    </channel>'
-    '</rss>'
-)
-
-for appcast in "${APPCAST[@]}"; do
-    echo "${appcast}" >> ./Artifacts/appcast.xml
-done

--- a/.github/prepRelease.sh
+++ b/.github/prepRelease.sh
@@ -16,6 +16,7 @@
 #
 
 cd $GITHUB_WORKSPACE
+
 eval $(grep -m 1 "MARKETING_VERSION" HeliPort.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
 
 echo "::set-env name=NEWVER::$MARKETING_VERSION"

--- a/.github/prepRelease.sh
+++ b/.github/prepRelease.sh
@@ -1,4 +1,20 @@
 #!/bin/zsh
+
+#
+#  prepRelease.sh
+#  HeliPort
+#
+#  Created by Bat.bat on 2020/6/10.
+#  Copyright © 2020 lhy. All rights reserved.
+#
+
+#
+#  This program and the accompanying materials are licensed and made available
+#  under the terms and conditions of the The 3-Clause BSD License
+#  which accompanies this distribution. The full text of the license may be found at
+#  https://opensource.org/licenses/BSD-3-Clause
+#
+
 cd $GITHUB_WORKSPACE
 eval $(grep -m 1 "MARKETING_VERSION" HeliPort.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
 

--- a/.github/sparkleAppcast.sh
+++ b/.github/sparkleAppcast.sh
@@ -32,13 +32,13 @@ APPCAST=(
     '            ]]>'
     '            </description>'
     "            <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>"
-    "            <enclosure url=\"https://github.com/zxystd/HeliPort/releases/latest/download/HeliPort.zip\" sparkle:version=\"${NEWVER}\" sparkle:shortVersionString=\"${NEWVER}\" type=\"application/octet-stream\" $(./sparkle/bin/sign_update -s ${SPARKLE_KEY} ./Artifacts/HeliPort.zip)/>"
+    "            <enclosure url=\"https://heliport.bat-bat.workers.dev/https://github.com/zxystd/HeliPort/releases/latest/download/HeliPort.zip\" sparkle:version=\"${NEWVER}\" sparkle:shortVersionString=\"${NEWVER}\" type=\"application/octet-stream\" $(./sparkle/bin/sign_update -s ${SPARKLE_KEY} ./Artifacts/HeliPort.zip)/>"
     '        </item>'
     '    </channel>'
     '</rss>'
 )
 
-sleep 10
+sleep 5
 
 for appcast in "${APPCAST[@]}"; do
     echo "${appcast}" >> ./Artifacts/appcast.xml

--- a/.github/sparkleAppcast.sh
+++ b/.github/sparkleAppcast.sh
@@ -1,0 +1,45 @@
+#!/bin/zsh
+
+#
+#  sparkleAppcast.sh
+#  HeliPort
+#
+#  Created by Bat.bat on 2020/6/11.
+#  Copyright © 2020 lhy. All rights reserved.
+#
+
+#
+#  This program and the accompanying materials are licensed and made available
+#  under the terms and conditions of the The 3-Clause BSD License
+#  which accompanies this distribution. The full text of the license may be found at
+#  https://opensource.org/licenses/BSD-3-Clause
+#
+
+cd $GITHUB_WORKSPACE
+
+PUBDATE="$(date +"%a, %d %b %Y %T %z")"
+
+APPCAST=(
+    '<?xml version="1.0" standalone="yes"?>'
+    '<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">'
+    '    <channel>'
+    '        <title>HeliPort</title>'
+    '        <item>'
+    "            <title>${NEWVER}</title>"
+    "            <pubDate>${PUBDATE}</pubDate>"
+    '            <description><![CDATA['
+    "                <link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/Primer/14.4.0/primer.min.css\"><meta charset=\"UTF-8\"> $(curl -L --silent https://github.com/zxystd/HeliPort/releases/latest | sed -n '/<div class=\"markdown-body\">/,/<\/div>/p' | tr -d '\n')"
+    '            ]]>'
+    '            </description>'
+    "            <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>"
+    "            <enclosure url=\"https://github.com/zxystd/HeliPort/releases/latest/download/HeliPort.zip\" sparkle:version=\"${NEWVER}\" sparkle:shortVersionString=\"${NEWVER}\" type=\"application/octet-stream\" $(./sparkle/bin/sign_update -s ${SPARKLE_KEY} ./Artifacts/HeliPort.zip)/>"
+    '        </item>'
+    '    </channel>'
+    '</rss>'
+)
+
+sleep 10
+
+for appcast in "${APPCAST[@]}"; do
+    echo "${appcast}" >> ./Artifacts/appcast.xml
+done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,30 +33,7 @@ jobs:
     - name: Prepare GH Release
       if: github.event_name == 'push' && contains(github.event.head_commit.message, 'GH release')
       run: |
-        eval $(grep -m 1 "MARKETING_VERSION" HeliPort.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
-        
-        # Unless this project becomes insane, there's no chance that the version number will be larger than 9.9.9
-        # Don't bump version for tag since we're using keywords for releases (Drafts can't be overridden in GH Actions)
-        #if [[ ${MARKETING_VERSION##*.} == 9 ]]; then
-        #    if [[ ${MARKETING_VERSION:2:1} == 9 ]]; then
-        #        NewVer="$((${MARKETING_VERSION:0:1}+1)).0.0"
-        #    else
-        #        NewVer="${MARKETING_VERSION:0:1}.$((${MARKETING_VERSION:2:1}+1)).0"
-        #    fi
-        #else
-        #    NewVer="${MARKETING_VERSION%.*}.$((${MARKETING_VERSION##*.}+1))"
-        #fi
-        
-        #echo "::set-env name=NewVer::$NewVer"
-        echo "::set-env name=NewVer::$MARKETING_VERSION"
-        
-        #cd build/Build/Products/Release
-        cd build/Build/Products/Debug
-        zip -qr HeliPort-v${NewVer}.zip *.app
-        cd -
-        
-        git log -"$(git rev-list --count $(git rev-list --tags | head -n 1)..HEAD)" --format="- %H %s" | grep -v 'gitignore\|Repo\|Docs\|Merge\|yml\|CI\|Commit\|commit\|attributes' | sed  '/^$/d' >> ReleaseNotes.md
-
+        zsh .github/prepRelease.sh
 
     - name: GH Release
       if: github.event_name == 'push' && contains(github.event.head_commit.message, 'GH release')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,11 @@ jobs:
     - name: Prepare Env
       run: |
         brew install swiftlint
+        pod install
 
     - name: Debug Build
       run: |
-        xcodebuild -scheme HeliPort -configuration Debug -derivedDataPath build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty && exit ${PIPESTATUS[0]}
+        xcodebuild -workspace HeliPort.xcworkspace -scheme HeliPort -configuration Debug -derivedDataPath build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty && exit ${PIPESTATUS[0]}
 
     # Uncomment when ClientKit DSYM generation gets fixed
     #- name: Release Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: '20'
 
     - name: Prepare Env
       run: |
@@ -49,7 +51,8 @@ jobs:
       run: |
         zsh .github/sparkleAppcast.sh
       env:
-          NEWVER: ${{ env.NEWVER }}
+        NEWVER: ${{ env.NEWVER }}
+        SPARKLE_KEY: ${{ secrets.SPARKLE_KEY }}
 
     - name: GH Release
       if: github.event_name == 'push' && contains(github.event.head_commit.message, 'GH release')
@@ -57,6 +60,7 @@ jobs:
       with:
         allowUpdates: true
         replacesArtifacts: true
+        bodyFile: ReleaseNotes.md
         artifacts: "./Artifacts/*"
         tag: "v${{ env.NEWVER }}"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,13 +35,28 @@ jobs:
       run: |
         zsh .github/prepRelease.sh
 
+    - name: Init GH Release
+      if: github.event_name == 'push' && contains(github.event.head_commit.message, 'GH release')
+      uses: ncipollo/release-action@v1
+      with:
+        bodyFile: ReleaseNotes.md
+        replacesArtifacts: false
+        tag: "v${{ env.NEWVER }}"
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate Sparkle Appcast
+      if: github.event_name == 'push' && contains(github.event.head_commit.message, 'GH release')
+      run: |
+        zsh .github/sparkleAppcast.sh
+      env:
+          NEWVER: ${{ env.NEWVER }}
+
     - name: GH Release
       if: github.event_name == 'push' && contains(github.event.head_commit.message, 'GH release')
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "build/Build/Products/Debug/*.zip"
-        bodyFile: ReleaseNotes.md
-        replacesArtifacts: false
-        draft: false
-        tag: "v${{ env.NewVer }}"
+        allowUpdates: true
+        replacesArtifacts: true
+        artifacts: "./Artifacts/*"
+        tag: "v${{ env.NEWVER }}"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ xcuserdata/
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout
+*.xcworkspace/xcshareddata/*
 
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -41,12 +41,7 @@ playground.xcworkspace
 .build/
 
 # CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# Pods/
+Pods/
 
 # Temp files
 TMP.strings

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ Pods/
 # Temp files
 TMP.strings
 NEW.strings
+Artifacts/
+sparkle/
+ReleaseNotes.md

--- a/HeliPort.xcodeproj/project.pbxproj
+++ b/HeliPort.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		BCFA32EB2424D2BE00E23603 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFA32EA2424D2BE00E23603 /* AppDelegate.swift */; };
 		BCFA32ED2424D2BF00E23603 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BCFA32EC2424D2BF00E23603 /* Assets.xcassets */; };
 		BCFA32F02424D2BF00E23603 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = BCFA32EE2424D2BF00E23603 /* MainMenu.xib */; };
+		D47DD664F9B2939B57C54DF4 /* Pods_HeliPort.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEE10AB0115816EC5C117043 /* Pods_HeliPort.framework */; };
 		F84E327924457FAE00D07895 /* ItlNetworkUserClient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F84E327724457FAE00D07895 /* ItlNetworkUserClient.hpp */; };
 		F86A8960243CD13300CBABC2 /* TestService.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F86A895F243CD13300CBABC2 /* TestService.hpp */; };
 		F86A8962243CD13400CBABC2 /* TestService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F86A8961243CD13400CBABC2 /* TestService.cpp */; };
@@ -58,6 +59,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2B879D3A8D737E5EF06C350F /* Pods-HeliPort.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeliPort.release.xcconfig"; path = "Target Support Files/Pods-HeliPort/Pods-HeliPort.release.xcconfig"; sourceTree = "<group>"; };
 		508D9C6724838D540025701D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		508D9C6E248393910025701D /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; lineEnding = 0; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		7562BBE324826102008A9BD2 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 		BCFA32EF2424D2BF00E23603 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		BCFA32F12424D2BF00E23603 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BCFA32F22424D2BF00E23603 /* HeliPort.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HeliPort.entitlements; sourceTree = "<group>"; };
+		DEE10AB0115816EC5C117043 /* Pods_HeliPort.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HeliPort.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F84E327624457FAE00D07895 /* ItlNetworkUserClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ItlNetworkUserClient.cpp; sourceTree = "<group>"; };
 		F84E327724457FAE00D07895 /* ItlNetworkUserClient.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ItlNetworkUserClient.hpp; sourceTree = "<group>"; };
 		F86A895D243CD13000CBABC2 /* TestService.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestService.kext; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -90,6 +93,7 @@
 		F8F6CF0A243D675800965B43 /* Api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Api.h; sourceTree = "<group>"; };
 		F8F6CF0B243D675800965B43 /* Api.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = Api.c; sourceTree = "<group>"; };
 		F8F6CF0E243D67D800965B43 /* IoctlId.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IoctlId.h; sourceTree = "<group>"; };
+		FD651AE794A9A932898331AD /* Pods-HeliPort.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeliPort.debug.xcconfig"; path = "Target Support Files/Pods-HeliPort/Pods-HeliPort.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +101,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D47DD664F9B2939B57C54DF4 /* Pods_HeliPort.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,6 +122,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		27E333CBDEE9F043281383C3 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				FD651AE794A9A932898331AD /* Pods-HeliPort.debug.xcconfig */,
+				2B879D3A8D737E5EF06C350F /* Pods-HeliPort.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		A3DAA5EDB2CAD33F8A53CAD7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DEE10AB0115816EC5C117043 /* Pods_HeliPort.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		BCF712FA243C9EB100BE3C05 /* Appearance */ = {
 			isa = PBXGroup;
 			children = (
@@ -140,6 +163,8 @@
 				F86A895E243CD13100CBABC2 /* TestService */,
 				F86A896C243CD1B500CBABC2 /* ClientKit */,
 				BCFA32E82424D2BE00E23603 /* Products */,
+				27E333CBDEE9F043281383C3 /* Pods */,
+				A3DAA5EDB2CAD33F8A53CAD7 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -233,10 +258,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BCFA32F52424D2BF00E23603 /* Build configuration list for PBXNativeTarget "HeliPort" */;
 			buildPhases = (
+				D0F7C8CBDEABDEEE298EDA22 /* [CP] Check Pods Manifest.lock */,
 				BCFA32E32424D2BE00E23603 /* Sources */,
 				BCFA32E42424D2BE00E23603 /* Frameworks */,
 				BCFA32E52424D2BE00E23603 /* Resources */,
 				75E3976A2487FAF600E84DB8 /* Lint */,
+				06A84524B547923DB0EAD0C7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -348,6 +375,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		06A84524B547923DB0EAD0C7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeliPort/Pods-HeliPort-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeliPort/Pods-HeliPort-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HeliPort/Pods-HeliPort-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		75E3976A2487FAF600E84DB8 /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -365,6 +409,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n\n";
+		};
+		D0F7C8CBDEABDEEE298EDA22 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HeliPort-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -553,6 +619,7 @@
 		};
 		BCFA32F62424D2BF00E23603 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD651AE794A9A932898331AD /* Pods-HeliPort.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = HeliPort/HeliPort.entitlements;
@@ -576,6 +643,7 @@
 		};
 		BCFA32F72424D2BF00E23603 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2B879D3A8D737E5EF06C350F /* Pods-HeliPort.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = HeliPort/HeliPort.entitlements;

--- a/HeliPort.xcworkspace/contents.xcworkspacedata
+++ b/HeliPort.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:HeliPort.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/HeliPort/Appearance/Base.lproj/MainMenu.xib
+++ b/HeliPort/Appearance/Base.lproj/MainMenu.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -11,7 +12,8 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Catch_Bat" customModuleProvider="target"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="HeliPort" customModuleProvider="target"/>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+        <customObject id="BIe-Qt-wTP" customClass="SUUpdater"/>
     </objects>
 </document>

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -97,14 +97,18 @@ class StatusMenu: NSMenu, NSMenuDelegate {
         for idx in 0...5 {
             items[idx].isHidden = true
         }
-        items[items.count - 1].isHidden = true
+        for idx in 1...2 {
+            items[items.count - idx].isHidden = true
+        }
     }
 
     func buildOptionMenu() {
         for idx in 0...5 {
             items[idx].isHidden = false
         }
-        items[items.count - 1].isHidden = false
+        for idx in 1...2 {
+            items[items.count - idx].isHidden = false
+        }
     }
 
     @objc func clickMenuItem(_ sender: NSMenuItem) {

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -15,8 +15,11 @@
 
 import Foundation
 import Cocoa
+import Sparkle
 
 class StatusMenu: NSMenu, NSMenuDelegate {
+    let heliPortUpdater = SUUpdater()
+
     let networkListUpdatePeriod: Double = 10
 
     var headerLength: Int = 0
@@ -63,6 +66,7 @@ class StatusMenu: NSMenu, NSMenuDelegate {
         addItem(withTitle: NSLocalizedString("Join Other Network...", comment: ""), action: #selector(clickMenuItem(_:)), keyEquivalent: "").target = self
         addItem(withTitle: NSLocalizedString("Create Network...", comment: ""), action: #selector(clickMenuItem(_:)), keyEquivalent: "").target = self
         addItem(withTitle: NSLocalizedString("Open Network Preferences...", comment: ""), action: #selector(clickMenuItem(_:)), keyEquivalent: "").target = self
+        addItem(withTitle: NSLocalizedString("Check for Updates...", comment: ""), action: #selector(clickMenuItem(_:)), keyEquivalent: "").target = self
         addItem(withTitle: NSLocalizedString("Quit HeliPort", comment: ""), action: #selector(clickMenuItem(_:)), keyEquivalent: "Q").target = self
     }
 
@@ -130,6 +134,8 @@ class StatusMenu: NSMenu, NSMenuDelegate {
             alert.runModal()
         case NSLocalizedString("Open Network Preferences...", comment: ""):
             NSWorkspace.shared.openFile("/System/Library/PreferencePanes/Network.prefPane")
+        case NSLocalizedString("Check for Updates...", comment: ""):
+            heliPortUpdater.checkForUpdates(self)
         case NSLocalizedString("Quit HeliPort", comment: ""):
             exit(0)
         default:

--- a/HeliPort/Appearance/zh-Hans.lproj/Localizable.strings
+++ b/HeliPort/Appearance/zh-Hans.lproj/Localizable.strings
@@ -1,5 +1,6 @@
 "Address: aa:bb:cc:dd:ee:ff" = "地址：aa:bb:cc:dd:ee:ff";
 "Cancel" = "取消";
+"Check for Updates..." = "检查更新...";
 "Create Diagnostics Report..." = "创建诊断报告...";
 "Create Network..." = "创建网络...";
 "Dynamic WEP" = "动态WEP";

--- a/HeliPort/HeliPort.entitlements
+++ b/HeliPort/HeliPort.entitlements
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
-    <key>com.apple.security.temporary-exception.sbpl</key>
-    <array>
-        <string>(allow iokit-open (iokit-user-client-class "ItlNetworkUserClient"))</string>
-    </array>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.sbpl</key>
+	<array>
+		<string>(allow iokit-open (iokit-user-client-class &quot;ItlNetworkUserClient&quot;))</string>
+	</array>
 </dict>
 </plist>

--- a/HeliPort/Info.plist
+++ b/HeliPort/Info.plist
@@ -34,5 +34,9 @@
 	<true/>
 	<key>NSSupportsSuddenTermination</key>
 	<true/>
+	<key>SUFeedURL</key>
+	<string>https://github.com/zxystd/HeliPort/releases/latest/download/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>ktrt51VPmrIyECEE/mqZCmOSNFBX6HLCpP+OB1V6G28=</string>
 </dict>
 </plist>

--- a/HeliPort/Info.plist
+++ b/HeliPort/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/HeliPort/Info.plist
+++ b/HeliPort/Info.plist
@@ -35,7 +35,7 @@
 	<key>NSSupportsSuddenTermination</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://github.com/zxystd/HeliPort/releases/latest/download/appcast.xml</string>
+	<string>https://heliport.bat-bat.workers.dev/https://github.com/zxystd/HeliPort/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>ktrt51VPmrIyECEE/mqZCmOSNFBX6HLCpP+OB1V6G28=</string>
 </dict>

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,6 @@
+platform :osx, '10.12'
+
+target 'HeliPort' do
+  use_frameworks!
+  pod 'Sparkle'
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Sparkle (1.23.0)
+
+DEPENDENCIES:
+  - Sparkle
+
+SPEC REPOS:
+  trunk:
+    - Sparkle
+
+SPEC CHECKSUMS:
+  Sparkle: 55b1a87ba69d56913375a281546b7c82dec95bb0
+
+PODFILE CHECKSUM: bcca7a2057e6aa9084e6e4ce4cc19d2865a9c0dc
+
+COCOAPODS: 1.9.3


### PR DESCRIPTION
This PR implements a builtin updater using the Sparkle framework.

- [x] Add Sparkle via CocoaPods
- [x] CI: Setup CocoaPods
- [x] CI: Add EdDSA public key in `Info.plist`
- [x] ~~CI: Setup keychain for signing~~ Implemented by a workaround
- [x] CI: Publish `appcast.xml` to GH Release (or master/gitter?)
- [x] Setup EdDSA private key
- [x] Implement a separate tool/script to generate ReleaseNotes in `appcast.xml`
- [x] Implement a separate tool/script to generate signatures in `appcast.xml`
- [x] Create a Sparkle Object in MainMenu.xib
- [x] Add a menu item that calls SUUpdater
- [x] ~~Add [custom properties](https://sparkle-project.org/documentation/customization/) for Sparkle updater~~ Todo in another PR
- Todo later: Check itlwm API version and perform forced update (or showing warning alerts) when there's a version mismatch.

closes #8 