### PR TITLE
Fixed issue when 8 characters on password would not allow to join.

### DIFF
--- a/HeliPort/Appearance/JoinPopWindow.swift
+++ b/HeliPort/Appearance/JoinPopWindow.swift
@@ -308,6 +308,10 @@ class JoinPopWindow: NSWindow, NSTextFieldDelegate {
         isReleasedWhenClosed = false
         level = .floating
         center()
+        
+        // Set WPA Personal as default
+        securityPop?.selectItem(at: 3)
+        security(nil)
     }
 
     @objc func security(_ sender: Any?) {
@@ -508,7 +512,6 @@ class JoinPopWindow: NSWindow, NSTextFieldDelegate {
     }
 
     func controlTextDidChange(_ obj: Notification) {
-        controlJoinButton()
         if JoinPopWindow.passwdInputBox?.isHidden == false {
             JoinPopWindow.passwdSecureBox?.stringValue = (JoinPopWindow.passwdInputBox?.stringValue)!
         } else {
@@ -529,5 +532,7 @@ class JoinPopWindow: NSWindow, NSTextFieldDelegate {
             )
             JoinPopWindow.passwdInputBox?.stringValue = String((JoinPopWindow.passwdInputBox?.stringValue[..<index!])!)
         }
+        
+        controlJoinButton()
     }
 }


### PR DESCRIPTION
- Changed Security Option to start as WPA Personal just like native. #13 

For the 8 character issues, it looks like controlJoinButton was called out before passwdSecureBox would get the string from passwdInputBox.


BTW thank you guys for the amazing work!