### PR TITLE
Added support for " Show "Wi-Fi: Looking for Networks..." when itlwm …

### DIFF
--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -288,6 +288,9 @@ class StatusMenu: NSMenu, NSMenuDelegate {
             return
         }
 
+        DispatchQueue.main.async {
+            self.statusItem.title = NSLocalizedString("Wi-Fi: Looking for Networks...", comment: "")
+        }
         NetworkManager.scanNetwork(callback: { networkList in
             DispatchQueue.main.async {
                 self.isNetworkListEmpty = networkList.count == 0
@@ -297,6 +300,10 @@ class StatusMenu: NSMenu, NSMenuDelegate {
                         view.networkInfo = networkList.removeFirst()
                         view.visible = true
                     }
+                }
+                // If the wifi is turned off after a start of a scan, do not update to "Wi-Fi on".
+                if self.isNetworkEnabled {
+                    self.statusItem.title = NSLocalizedString("Wi-Fi: On", comment: "")
                 }
             }
         })

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -52,7 +52,11 @@ class StatusMenu: NSMenu, NSMenuDelegate {
     )
     var networkItemList = [NSMenuItem]()
     let maxNetworkListLength = MAX_NETWORK_LIST_LENGTH
-    let networkItemListSeparator = NSMenuItem.separator()
+    let networkItemListSeparator: NSMenuItem = {
+        let networkItemListSeparator =  NSMenuItem.separator()
+        networkItemListSeparator.isHidden = true
+        return networkItemListSeparator
+    }()
 
     var showAllOptions: Bool = false {
         willSet(visible) {
@@ -263,6 +267,12 @@ class StatusMenu: NSMenu, NSMenuDelegate {
             return item
         }
         view.visible = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        guard let supView = view.superview else {
+            return item
+        }
+        view.widthAnchor.constraint(equalTo: supView.widthAnchor).isActive = true
+        view.heightAnchor.constraint(equalTo: supView.heightAnchor).isActive = true
         return item
     }
 
@@ -295,7 +305,7 @@ class StatusMenu: NSMenu, NSMenuDelegate {
             DispatchQueue.main.async {
                 self.isNetworkListEmpty = networkList.count == 0
                 var networkList = networkList
-                for index in 0 ... self.networkItemList.count - 1 {
+                for index in 0 ..< self.networkItemList.count {
                     if networkList.count > 0, let view = self.networkItemList[index].view as? WifiMenuItemView {
                         view.networkInfo = networkList.removeFirst()
                         view.visible = true

--- a/HeliPort/Appearance/WiFiMenuItemView.swift
+++ b/HeliPort/Appearance/WiFiMenuItemView.swift
@@ -138,8 +138,6 @@ class WifiMenuItemView: NSView {
 
         addSubview(menuItemView)
         setupLayout()
-
-        autoresizingMask = [.width]
     }
 
     func checkHighlight() {
@@ -181,6 +179,8 @@ class WifiMenuItemView: NSView {
     func getRssiImage(_ RSSI: Int) -> NSImage? {
         var signalImageName: String
         switch RSSI {
+        case ..<(-100):
+            signalImageName = "WiFiSignalStrengthPoor"
         case ..<(-80):
             signalImageName = "WiFiSignalStrengthFair"
         case ..<(-60):


### PR DESCRIPTION
…is scanning" from https://github.com/zxystd/HeliPort/issues/21

- Fixed a leak where if there is more than one ethernet controller on Api.c

Working on adding the enhancements from https://github.com/zxystd/HeliPort/issues/21. As of now, I still need to figure out how to check if there is currently a network connected and get the SSID, especially if you close the app and open the app back up.