### PR TITLE
Fix incorrect singular title display when there are multiple networks

### DIFF
--- a/HeliPort/Appearance/StatusMenu/StatusMenuModern.swift
+++ b/HeliPort/Appearance/StatusMenu/StatusMenuModern.swift
@@ -200,7 +200,9 @@ final class StatusMenuModern: StatusMenuBase, StatusMenuItems {
             self.isNetworkListEmpty = networkListSize == 0 && !self.isNetworkConnected
             self.knownSectionItem.isHidden = knownList.isEmpty && !self.isNetworkConnected
             (self.knownSectionItem.view as? SectionMenuItemView)?
-                .title = (knownList.count > 1 ? .Modern.knownNetworks : .Modern.knownNetwork)
+                .title = (
+                    (self.isNetworkConnected ? knownList.count + 1 : knownList.count) > 1 ? .Modern.knownNetworks : .Modern.knownNetwork
+                )
 
             if otherList.isEmpty {
                 self.manuallyJoinItem.isHidden = false

--- a/HeliPort/Appearance/StatusMenu/StatusMenuModern.swift
+++ b/HeliPort/Appearance/StatusMenu/StatusMenuModern.swift
@@ -201,8 +201,8 @@ final class StatusMenuModern: StatusMenuBase, StatusMenuItems {
             self.knownSectionItem.isHidden = knownList.isEmpty && !self.isNetworkConnected
             (self.knownSectionItem.view as? SectionMenuItemView)?
                 .title = (
-                    (self.isNetworkConnected ? knownList.count + 1 : knownList.count) > 1 ? .Modern.knownNetworks : .Modern.knownNetwork
-                )
+                    (self.isNetworkConnected ? knownList.count + 1 : knownList.count) > 1 ?
+                        .Modern.knownNetworks : .Modern.knownNetwork)
 
             if otherList.isEmpty {
                 self.manuallyJoinItem.isHidden = false

--- a/HeliPort/Appearance/StatusMenu/StatusMenuModern.swift
+++ b/HeliPort/Appearance/StatusMenu/StatusMenuModern.swift
@@ -200,9 +200,8 @@ final class StatusMenuModern: StatusMenuBase, StatusMenuItems {
             self.isNetworkListEmpty = networkListSize == 0 && !self.isNetworkConnected
             self.knownSectionItem.isHidden = knownList.isEmpty && !self.isNetworkConnected
             (self.knownSectionItem.view as? SectionMenuItemView)?
-                .title = (
-                    (self.isNetworkConnected ? knownList.count + 1 : knownList.count) > 1 ?
-                        .Modern.knownNetworks : .Modern.knownNetwork)
+                .title = ((self.isNetworkConnected ? knownList.count + 1 : knownList.count) > 1 ?
+                          .Modern.knownNetworks : .Modern.knownNetwork)
 
             if otherList.isEmpty {
                 self.manuallyJoinItem.isHidden = false


### PR DESCRIPTION
- Adds network connection check (`self.isNetworkConnected`) to the count logic.
- Ensures that if the network is connected, 1 is added to the known items count (`knownList.count`), fixing the issue where the title was displayed in singular form even with 2 known networks.