### PR TITLE
Minor typo in Spanish Localizable.xcstrings

### DIFF
--- a/HeliPort/Appearance/Localizable.xcstrings
+++ b/HeliPort/Appearance/Localizable.xcstrings
@@ -7086,7 +7086,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cambiar apariencia requiere reinicar la aplicación para que tenga efecto."
+            "value" : "Cambiar apariencia requiere reiniciar la aplicación para que tenga efecto."
           }
         },
         "zh-Hans" : {


### PR DESCRIPTION
To fix a typo in the Spanish localization. 
Greetings. 