### PR TITLE
fix Heliport Autostart on login on newer MacOS

### DIFF
--- a/HeliPort/Info.plist
+++ b/HeliPort/Info.plist
@@ -44,6 +44,18 @@
 			<dict/>
 		</dict>
 	</array>
+	<key>SMAppService</key>
+	<dict>
+		<key>LoginItems</key>
+		<array>
+			<dict>
+				<key>Identifier</key>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)-Launcher</string>
+				<key>Enabled</key>
+				<true />
+			</dict>
+		</array>
+	</dict>
 	<key>NSSupportsAutomaticTermination</key>
 	<true/>
 	<key>NSSupportsSuddenTermination</key>


### PR DESCRIPTION
This PR should fix #275 to make the autologin working again on newer MacOS version. If an older MacOS version is detected, the old autologin autostart feature will be used.