### PR TITLE
[codex] Modern UI memory fixes and Wi-Fi diagnostics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,222 +1,59 @@
-name: CI
+name: Build
 
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-
-  CI:
+  build:
+    name: Build HeliPort
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - uses: actions/cache@v4
-      with:
-        path: build/SourcePackages
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
+      - name: Select Xcode
+        run: |
+          xcodebuild -version
+          xcode-select -p
 
-    - name: Install Dependencies
-      run: |
-        brew install create-dmg swiftlint
-        python -m pip install pycountry
-      env:
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-        HOMEBREW_NO_AUTO_UPDATE: 1
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: build/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('HeliPort.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
-    - name: Manage Version
-      if: (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'workflow_dispatch'
-      run: |
-        git fetch --prune --unshallow --tags
-        GIT_SHA="$(git rev-parse --short HEAD)"
-        CUR_TAG="$(git tag -l | grep -i 'alpha' | tail -1)"
-        eval $(grep -m 1 "MARKETING_VERSION =" HeliPort.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
+      - name: Resolve packages
+        run: |
+          xcodebuild \
+            -project HeliPort.xcodeproj \
+            -scheme HeliPort \
+            -derivedDataPath build \
+            -resolvePackageDependencies
 
-        if [[ "$GITHUB_EVENT_NAME" != 'workflow_dispatch' ]]; then
-          sed -i '' -e "s/CURRENT_PROJECT_VERSION =.*/CURRENT_PROJECT_VERSION = \"\$(MARKETING_VERSION)-alpha-${GIT_SHA}\";/g" HeliPort.xcodeproj/project.pbxproj
-        else
-          sed -i '' -e "s/CURRENT_PROJECT_VERSION =.*/CURRENT_PROJECT_VERSION = \"\$(MARKETING_VERSION)-stable-${GIT_SHA}\";/g" HeliPort.xcodeproj/project.pbxproj
-        fi
+      - name: Build unsigned debug app
+        run: |
+          xcodebuild \
+            -project HeliPort.xcodeproj \
+            -scheme HeliPort \
+            -configuration Debug \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
 
-        echo "VER=$MARKETING_VERSION" >> $GITHUB_ENV
-        echo "SHORT_SHA=$GIT_SHA" >> $GITHUB_ENV
-        if [[ -z $CUR_TAG ]]; then
-          echo "OLD_PRE_TAG=NULL" >> $GITHUB_ENV
-        else
-          echo "OLD_PRE_TAG=$CUR_TAG">> $GITHUB_ENV
-        fi
-      shell: zsh {0}
+      - name: Package app artifact
+        run: |
+          cd build/Build/Products/Debug
+          ditto -c -k --keepParent HeliPort.app HeliPort-debug-unsigned.zip
 
-    - name: Lint
-      run: swiftlint lint --reporter github-actions-logging
-
-    - name: i18n Stats
-      run: |
-        import os, sys, json
-        from pycountry import languages
-        from collections import defaultdict
-
-        def get_lang_name(code):
-            if '-' in code:
-                code = code.split('-')[0]
-            lang = languages.get(alpha_2=code)
-            return lang.name if lang else code
-
-        def write_stats(file_path):
-            with open(file_path, 'r', encoding='utf-8') as file:
-                data = json.load(file)
-
-            if data["version"] != "1.0":
-                raise ValueError(f"Unsupported version: {data['version']}")
-
-            strings = data["strings"]
-            localizations = defaultdict(int)
-
-            for string in strings.values():
-                for lang_code in string["localizations"].keys():
-                    localizations[lang_code] += 1
-
-            summary = ["## i18n Stats", "",
-                      "| Language | Code | Completion |",
-                      "| :-- | :-- | --: |"]
-
-            for lang_code, count in localizations.items():
-                summary.append(f"| {get_lang_name(lang_code)} | {lang_code} | {(count / len(strings) * 100):.2f}% |")
-
-            summary.extend(["",
-                            f"- **Total Languages**: {len(localizations)}",
-                            f"- **Total Strings**: {len(strings)}"])
-
-            with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
-                f.write('\n'.join(summary) + '\n')
-
-        try:
-            write_stats("HeliPort/Appearance/Localizable.xcstrings")
-        except Exception as e:
-            print(f"::error::{str(e)}")
-            sys.exit(1)
-
-      shell: python
-
-    - name: Debug Build
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        set -o pipefail && xcodebuild ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO -scheme HeliPort -configuration Debug -derivedDataPath build -disableAutomaticPackageResolution CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify --renderer terminal
-
-    - name: Release Build
-      run: |
-        set -o pipefail && xcodebuild ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO -scheme HeliPort -configuration Release -derivedDataPath build -disableAutomaticPackageResolution CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify
-
-    - name: Create Disk Image
-      if: (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'workflow_dispatch'
-      run: |
-        XCBUILD_PATH="build/Build/Products/Release"
-        cp LICENSE $XCBUILD_PATH
-        cd $XCBUILD_PATH
-        curl -sLO https://openintelwireless.github.io/HeliPort/dmg/VolumeIcon.icns
-        curl -sLO https://openintelwireless.github.io/HeliPort/dmg/dmg-background.tiff
-        create-dmg \
-          --volname "HeliPort" \
-          --volicon "VolumeIcon.icns" \
-          --background "dmg-background.tiff" \
-          --window-pos 200 120 \
-          --window-size 660 420 \
-          --text-size 12 \
-          --eula "LICENSE" \
-          --icon-size 160 \
-          --icon "HeliPort.app" 180 170 \
-          --hide-extension "HeliPort.app" \
-          --app-drop-link 480 170 \
-          "HeliPort.dmg" \
-          "./HeliPort.app"
-        cd -
-        mkdir Artifacts
-        cp -R ${XCBUILD_PATH}/*.dmg Artifacts
-
-    - name: Setup Prerelease Variables
-      if: github.event_name == 'push' && github.ref_name == 'master'
-      run: |
-        echo "REL_TAG=v${VER}-alpha" >> $GITHUB_ENV
-        echo "IS_PRE=true" >> $GITHUB_ENV
-
-        echo '### Disclaimer:' >> ReleaseNotes.md
-        echo '***This alpha version is for testing only.***' >> ReleaseNotes.md
-        echo 'It is not ready for daily use and we do not guarantee its usability.' >> ReleaseNotes.md
-        echo 'If you discovered an issue and you do not have debugging skills, please check with the [Gitter Chat Room](https://gitter.im/OpenIntelWireless/itlwm) in advance before opening an Issue.' >> ReleaseNotes.md
-
-    - name: Setup Release Variables
-      if: github.event_name == 'workflow_dispatch'
-      run: |
-        echo "REL_TAG=v${VER}" >> $GITHUB_ENV
-        echo "IS_PRE=false" >> $GITHUB_ENV
-
-    - name: Generate Release Notes
-      if: (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'workflow_dispatch'
-      run: |
-        echo '### The latest updates are:' >> ReleaseNotes.md
-        git log -"$(git rev-list --count $(git rev-list -1 "$(git tag -l | grep -v 'alpha' | tail -1)")..HEAD)" --format="- %H %s" | grep -v '.git\|Merge\|yml\|CI' | sed  '/^$/d' >> ReleaseNotes.md
-
-    - name: Delete Old Prerelease
-      if: (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'workflow_dispatch'
-      run: gh release delete ${{ env.OLD_PRE_TAG }} --cleanup-tag
-      continue-on-error: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Generate Sparkle Appcast
-      if: github.event_name == 'workflow_dispatch'
-      run: |
-        REPO_COMMIT_URL='https://github.com/OpenIntelWireless/HeliPort/commit/'
-        INDENT='                    '
-        PART1="${INDENT}<li><a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"${REPO_COMMIT_URL}"
-        PART2="/hovercard\" href=\"${REPO_COMMIT_URL}"
-        PART3="\"><tt>"
-        PART4='</tt></a> '
-        PART5='</li>'
-        CHANGELOG="$(git log -"$(git rev-list --count $(git rev-list -1 "$(git tag -l | grep -v 'alpha' | tail -1)")..HEAD)" --format="${PART1}%H${PART2}%H${PART3}%h${PART4}%s${PART5}" | cat)"
-
-        SPARKLE_BIN='./build/SourcePackages/artifacts/sparkle/Sparkle/bin'
-        PUBDATE="$(date +"%a, %d %b %Y %T %z")"
-        APPCAST=(
-            '<?xml version="1.0" standalone="yes"?>'
-            '<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">'
-            '    <channel>'
-            '        <title>HeliPort</title>'
-            '        <item>'
-            "            <title>${VER}</title>"
-            "            <pubDate>${PUBDATE}</pubDate>"
-            '            <description><![CDATA['
-            '                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Primer/19.4.0/primer.min.css"><meta charset="UTF-8"><div class="markdown-body"><h3>The latest updates are:</h3><ul>'
-            "${CHANGELOG}"
-            '                </ul></div>'
-            '            ]]>'
-            '            </description>'
-            '            <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>'
-            "            <enclosure url=\"https://github.com/OpenIntelWireless/HeliPort/releases/latest/download/HeliPort.dmg\" sparkle:version=\"${VER}-stable-${SHORT_SHA}\" sparkle:shortVersionString=\"${VER}\" type=\"application/octet-stream\" $($SPARKLE_BIN/sign_update -s ${SPARKLE_KEY} ./Artifacts/HeliPort.dmg)/>"
-            '        </item>'
-            '    </channel>'
-            '</rss>'
-        )
-
-        for appcast in "${APPCAST[@]}"; do
-            echo "${appcast}" >> ./Artifacts/appcast.xml
-        done
-      shell: zsh {0}
-      env:
-        SPARKLE_KEY: ${{ secrets.SPARKLE_KEY }}
-
-    - name: Publish GitHub Release
-      if: ((github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'workflow_dispatch') && contains(github.event.head_commit.message, 'Bump version') == false
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: true
-        replacesArtifacts: true
-        prerelease: ${{ env.IS_PRE }}
-        bodyFile: ReleaseNotes.md
-        artifacts: "./Artifacts/*"
-        tag: ${{ env.REL_TAG }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: HeliPort-debug-unsigned
+          path: build/Build/Products/Debug/HeliPort-debug-unsigned.zip

--- a/HeliPort/AppDelegate.swift
+++ b/HeliPort/AppDelegate.swift
@@ -83,10 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let pathComponents = (Bundle.main.bundlePath as NSString).pathComponents
 
 #if DEBUG
-        // Normal users should never use the Debug Version
-        guard pathComponents[pathComponents.count - 2] != "Debug" else {
-            return
-        }
+        return
 #else
         guard pathComponents[pathComponents.count - 2] != "Applications" else {
             return

--- a/HeliPort/Appearance/Preferences/PrefsGeneralView.swift
+++ b/HeliPort/Appearance/Preferences/PrefsGeneralView.swift
@@ -64,6 +64,21 @@ class PrefsGeneralView: NSView {
         return checkbox
     }()
 
+    let advancedLabel: NSTextField = {
+        let view = NSTextField(labelWithString: .advanced)
+        view.alignment = .right
+        return view
+    }()
+
+    lazy var showDuplicateSSIDsCheckbox: NSButton = {
+        let checkbox = NSButton(checkboxWithTitle: .showDuplicateSSIDs,
+                                target: self,
+                                action: #selector(self.checkboxChanged(_:)))
+        checkbox.identifier = .showDuplicateSSIDsId
+        checkbox.state = UserDefaults.standard.bool(forKey: .DefaultsKey.showDuplicateSSIDsByBSSID) ? .on : .off
+        return checkbox
+    }()
+
     let gridView: NSGridView = {
         let view = NSGridView()
         view.setContentHuggingPriority(.init(rawValue: 600), for: .horizontal)
@@ -81,6 +96,8 @@ class PrefsGeneralView: NSView {
         gridView.addColumn(with: [autoUpdateCheckbox, autoDownloadCheckbox])
         let appearanceRow = gridView.addRow(with: [appearanceLabel, legacyUICheckbox])
         appearanceRow.topPadding = 5
+        let advancedRow = gridView.addRow(with: [advancedLabel, showDuplicateSSIDsCheckbox])
+        advancedRow.topPadding = 5
 
         addSubview(gridView)
         setupConstraints()
@@ -122,6 +139,8 @@ extension PrefsGeneralView {
                     NSApp.restartApp()
                 }
             }
+        case .showDuplicateSSIDsId:
+            UserDefaults.standard.set(sender.state == .on, forKey: .DefaultsKey.showDuplicateSSIDsByBSSID)
         default:
             break
         }
@@ -133,6 +152,7 @@ private extension NSUserInterfaceItemIdentifier {
     static let autoDownloadId = NSUserInterfaceItemIdentifier(rawValue: "AutoDownloadCheckbox")
 
     static let legacyUIId = NSUserInterfaceItemIdentifier(rawValue: "legacyUICheckbox")
+    static let showDuplicateSSIDsId = NSUserInterfaceItemIdentifier(rawValue: "showDuplicateSSIDsCheckbox")
 }
 
 private extension String {
@@ -142,6 +162,8 @@ private extension String {
 
     static let appearance = NSLocalizedString("Appearance:")
     static let useLegacyUI = NSLocalizedString("Use Legacy UI")
+    static let advanced = NSLocalizedString("Advanced:")
+    static let showDuplicateSSIDs = NSLocalizedString("Show duplicate SSIDs by BSSID")
 
     static let heliportRestart = NSLocalizedString("HeliPort Restart Required")
     static let restartInfoText =

--- a/HeliPort/Appearance/Preferences/PrefsSavedNetworksView.swift
+++ b/HeliPort/Appearance/Preferences/PrefsSavedNetworksView.swift
@@ -20,6 +20,7 @@ class PrefsSavedNetworksView: NSView {
     // MARK: Saved networks array
 
     private var savedNetworks: [NetworkInfoStorageEntity] = []
+    private var activeObserver: NSObjectProtocol?
 
     // MARK: Properties
 
@@ -115,18 +116,25 @@ class PrefsSavedNetworksView: NSView {
         addSubview(orderItemsLabel)
 
         setupConstraints()
+        reloadSavedNetworks()
 
-        DispatchQueue.global(qos: .background).async {
-            self.savedNetworks = CredentialsManager.instance.getSavedNetworksEntity()
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
-                NSApplication.shared.activate(ignoringOtherApps: true)
-            }
+        activeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.reloadSavedNetworks()
         }
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if let activeObserver {
+            NotificationCenter.default.removeObserver(activeObserver)
+        }
     }
 
     private func setupConstraints() {
@@ -146,6 +154,18 @@ class PrefsSavedNetworksView: NSView {
 
         orderItemsLabel.leadingAnchor.constraint(equalTo: modifyItemSegment.trailingAnchor, constant: 4).isActive = true
         orderItemsLabel.centerYAnchor.constraint(equalTo: modifyItemSegment.centerYAnchor).isActive = true
+    }
+
+    private func reloadSavedNetworks() {
+        DispatchQueue.global(qos: .background).async {
+            let savedNetworks = CredentialsManager.instance.getSavedNetworksEntity()
+            DispatchQueue.main.async {
+                self.savedNetworks = savedNetworks
+                self.tableView.reloadData()
+                self.modifyItemSegment.setEnabled(false, forSegment: .remove)
+                self.modifyItemSegment.setEnabled(false, forSegment: .view)
+            }
+        }
     }
 
     private func updateNetworkPriority() {

--- a/HeliPort/Appearance/Preferences/PrefsWindow.swift
+++ b/HeliPort/Appearance/Preferences/PrefsWindow.swift
@@ -48,6 +48,7 @@ class PrefsWindow: NSWindow {
         toolbar!.insertItem(withItemIdentifier: .general, at: 0)
         toolbar!.insertItem(withItemIdentifier: .networks, at: 1)
         toolbar!.insertItem(withItemIdentifier: .current, at: 2)
+        toolbar!.insertItem(withItemIdentifier: .app, at: 3)
         toolbar!.selectedItemIdentifier = .general
 
         if #available(OSX 11.0, *) {
@@ -99,6 +100,9 @@ class PrefsWindow: NSWindow {
         case .general:
             newView = PrefsGeneralView()
             size = newView!.fittingSize
+        case .app:
+            newView = PrefsAppView()
+            size = NSSize(width: 320, height: 180)
         default:
             Log.error("Toolbar Item not implemented: \(identifier)")
         }
@@ -117,15 +121,15 @@ class PrefsWindow: NSWindow {
 extension PrefsWindow: NSToolbarDelegate {
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [.general, .networks, .current]
+        return [.general, .networks, .current, .app]
     }
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [.general, .networks, .current]
+        return [.general, .networks, .current, .app]
     }
 
     func toolbarSelectableItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [.general, .networks, .current]
+        return [.general, .networks, .current, .app]
     }
 
     func toolbar(_ toolbar: NSToolbar,
@@ -168,6 +172,16 @@ extension PrefsWindow: NSToolbarDelegate {
             }
             toolbarItem.isEnabled = true
             return toolbarItem
+        case .app:
+            toolbarItem.label = .app
+            toolbarItem.paletteLabel = .app
+            if #available(OSX 11.0, *) {
+                toolbarItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: .app)
+            } else {
+                toolbarItem.image = NSImage(named: NSImage.stopProgressTemplateName)
+            }
+            toolbarItem.isEnabled = true
+            return toolbarItem
         default:
             return nil
         }
@@ -180,6 +194,7 @@ private extension NSToolbarItem.Identifier {
     static let networks = NSToolbarItem.Identifier("WiFiNetworks")
     static let current = NSToolbarItem.Identifier("CurrentWiFi")
     static let general = NSToolbarItem.Identifier("General")
+    static let app = NSToolbarItem.Identifier("App")
     static let none = NSToolbarItem.Identifier("none")
 }
 
@@ -190,6 +205,7 @@ private extension String {
     static let networks = NSLocalizedString("Networks")
     static let current = NSLocalizedString("Current")
     static let general = NSLocalizedString("General")
+    static let app = NSLocalizedString("App")
 }
 
 final class PrefsCurrentNetworkView: NSView {
@@ -313,4 +329,54 @@ private extension String {
     static let ipAddress = NSLocalizedString("IP Address:")
     static let router = NSLocalizedString("Router:")
     static let internet = NSLocalizedString("Internet:")
+}
+
+final class PrefsAppView: NSView {
+    private let titleLabel = NSTextField(labelWithString: .appActions)
+    private let quitButton: NSButton = {
+        let button = NSButton(title: .quitHeliport, target: nil, action: nil)
+        button.bezelStyle = .rounded
+        return button
+    }()
+
+    convenience init() {
+        self.init(frame: .zero)
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        quitButton.target = self
+        quitButton.action = #selector(quitApp)
+
+        addSubview(titleLabel)
+        addSubview(quitButton)
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupConstraints() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        quitButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 20),
+
+            quitButton.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            quitButton.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 16)
+        ])
+    }
+
+    @objc private func quitApp() {
+        NSApp.terminate(nil)
+    }
+}
+
+private extension String {
+    static let appActions = NSLocalizedString("App Actions")
+    static let quitHeliport = NSLocalizedString("Quit HeliPort")
 }

--- a/HeliPort/Appearance/Preferences/PrefsWindow.swift
+++ b/HeliPort/Appearance/Preferences/PrefsWindow.swift
@@ -39,6 +39,7 @@ class PrefsWindow: NSWindow {
                    defer: flag)
 
         isReleasedWhenClosed = false
+        minSize = NSSize(width: 560, height: 180)
 
         title = .networkPrefs
 
@@ -96,13 +97,14 @@ class PrefsWindow: NSWindow {
             size = NSSize(width: 620, height: 420)
         case .current:
             newView = PrefsCurrentNetworkView()
-            size = NSSize(width: 430, height: 340)
+            size = NSSize(width: 560, height: 340)
         case .general:
             newView = PrefsGeneralView()
-            size = newView!.fittingSize
+            size = NSSize(width: max(newView!.fittingSize.width, minSize.width),
+                          height: newView!.fittingSize.height)
         case .app:
             newView = PrefsAppView()
-            size = NSSize(width: 320, height: 180)
+            size = NSSize(width: 560, height: 180)
         default:
             Log.error("Toolbar Item not implemented: \(identifier)")
         }

--- a/HeliPort/Appearance/Preferences/PrefsWindow.swift
+++ b/HeliPort/Appearance/Preferences/PrefsWindow.swift
@@ -47,6 +47,7 @@ class PrefsWindow: NSWindow {
         toolbar!.displayMode = .iconAndLabel
         toolbar!.insertItem(withItemIdentifier: .general, at: 0)
         toolbar!.insertItem(withItemIdentifier: .networks, at: 1)
+        toolbar!.insertItem(withItemIdentifier: .current, at: 2)
         toolbar!.selectedItemIdentifier = .general
 
         if #available(OSX 11.0, *) {
@@ -92,6 +93,9 @@ class PrefsWindow: NSWindow {
         case .networks:
             newView = PrefsSavedNetworksView()
             size = NSSize(width: 620, height: 420)
+        case .current:
+            newView = PrefsCurrentNetworkView()
+            size = NSSize(width: 430, height: 340)
         case .general:
             newView = PrefsGeneralView()
             size = newView!.fittingSize
@@ -113,15 +117,15 @@ class PrefsWindow: NSWindow {
 extension PrefsWindow: NSToolbarDelegate {
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [.general, .networks]
+        return [.general, .networks, .current]
     }
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [.general, .networks]
+        return [.general, .networks, .current]
     }
 
     func toolbarSelectableItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [.general, .networks]
+        return [.general, .networks, .current]
     }
 
     func toolbar(_ toolbar: NSToolbar,
@@ -138,6 +142,17 @@ extension PrefsWindow: NSToolbarDelegate {
             toolbarItem.paletteLabel = .networks
             if #available(OSX 11.0, *) {
                 toolbarItem.image = NSImage(systemSymbolName: "wifi", accessibilityDescription: .general)
+            } else {
+                toolbarItem.image = #imageLiteral(resourceName: "WiFi")
+            }
+            toolbarItem.isEnabled = true
+            return toolbarItem
+        case .current:
+            toolbarItem.label = .current
+            toolbarItem.paletteLabel = .current
+            if #available(OSX 11.0, *) {
+                toolbarItem.image = NSImage(systemSymbolName: "dot.radiowaves.left.and.right",
+                                            accessibilityDescription: .current)
             } else {
                 toolbarItem.image = #imageLiteral(resourceName: "WiFi")
             }
@@ -163,6 +178,7 @@ extension PrefsWindow: NSToolbarDelegate {
 
 private extension NSToolbarItem.Identifier {
     static let networks = NSToolbarItem.Identifier("WiFiNetworks")
+    static let current = NSToolbarItem.Identifier("CurrentWiFi")
     static let general = NSToolbarItem.Identifier("General")
     static let none = NSToolbarItem.Identifier("none")
 }
@@ -172,5 +188,129 @@ private extension NSToolbarItem.Identifier {
 private extension String {
     static let networkPrefs = NSLocalizedString("Network Preferences")
     static let networks = NSLocalizedString("Networks")
+    static let current = NSLocalizedString("Current")
     static let general = NSLocalizedString("General")
+}
+
+final class PrefsCurrentNetworkView: NSView {
+    private let titleLabel = NSTextField(labelWithString: .currentNetwork)
+    private let statusLabel = NSTextField(labelWithString: .notConnected)
+    private let gridView: NSGridView = {
+        let view = NSGridView()
+        view.rowSpacing = 6
+        view.columnSpacing = 12
+        return view
+    }()
+    private var refreshTimer: Timer?
+    private var valueLabels = [String: NSTextField]()
+
+    convenience init() {
+        self.init(frame: .zero)
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        let rows: [(String, String)] = [
+            (.interfaceName, "interface"),
+            (.networkName, "ssid"),
+            (.bssid, "bssid"),
+            (.channel, "channel"),
+            (.rssi, "rssi"),
+            (.noise, "noise"),
+            (.txRate, "txRate"),
+            (.phyMode, "phyMode"),
+            (.ipAddress, "ipAddress"),
+            (.router, "router"),
+            (.internet, "internet")
+        ]
+
+        rows.forEach { title, key in
+            let keyLabel = NSTextField(labelWithString: title)
+            keyLabel.alignment = .right
+            let valueLabel = NSTextField(labelWithString: .unavailableValue)
+            valueLabel.lineBreakMode = .byTruncatingMiddle
+            valueLabels[key] = valueLabel
+            gridView.addRow(with: [keyLabel, valueLabel])
+        }
+
+        addSubview(titleLabel)
+        addSubview(statusLabel)
+        addSubview(gridView)
+        setupConstraints()
+        refresh()
+
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
+            self?.refresh()
+        }
+        if let refreshTimer {
+            RunLoop.main.add(refreshTimer, forMode: .common)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        refreshTimer?.invalidate()
+    }
+
+    private func setupConstraints() {
+        subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+
+        let inset: CGFloat = 20
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: inset),
+
+            statusLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            statusLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+
+            gridView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            gridView.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 12),
+            gridView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -inset),
+            gridView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -inset)
+        ])
+    }
+
+    private func refresh() {
+        DispatchQueue.global(qos: .background).async {
+            let info = NetworkManager.getCurrentNetworkInfo()
+            DispatchQueue.main.async {
+                self.statusLabel.stringValue = info.isConnected ? .connected : .notConnected
+                self.gridView.isHidden = !info.isConnected
+                guard info.isConnected else { return }
+                self.valueLabels["interface"]?.stringValue = info.interfaceName
+                self.valueLabels["ssid"]?.stringValue = info.ssid
+                self.valueLabels["bssid"]?.stringValue = info.bssid
+                self.valueLabels["channel"]?.stringValue = info.channel
+                self.valueLabels["rssi"]?.stringValue = info.rssi
+                self.valueLabels["noise"]?.stringValue = info.noise
+                self.valueLabels["txRate"]?.stringValue = info.txRate
+                self.valueLabels["phyMode"]?.stringValue = info.phyMode
+                self.valueLabels["ipAddress"]?.stringValue = info.ipAddress
+                self.valueLabels["router"]?.stringValue = info.router
+                self.valueLabels["internet"]?.stringValue = info.internet
+            }
+        }
+    }
+}
+
+private extension String {
+    static let currentNetwork = NSLocalizedString("Current Network:")
+    static let notConnected = NSLocalizedString("Not connected")
+    static let connected = NSLocalizedString("Connected")
+    static let unavailableValue = NSLocalizedString("Unavailable")
+    static let interfaceName = NSLocalizedString("Interface:")
+    static let networkName = NSLocalizedString("Network:")
+    static let bssid = NSLocalizedString("BSSID:")
+    static let channel = NSLocalizedString("Channel:")
+    static let rssi = NSLocalizedString("RSSI:")
+    static let noise = NSLocalizedString("Noise:")
+    static let txRate = NSLocalizedString("Tx Rate:")
+    static let phyMode = NSLocalizedString("PHY Mode:")
+    static let ipAddress = NSLocalizedString("IP Address:")
+    static let router = NSLocalizedString("Router:")
+    static let internet = NSLocalizedString("Internet:")
 }

--- a/HeliPort/Appearance/Preferences/PrefsWindow.swift
+++ b/HeliPort/Appearance/Preferences/PrefsWindow.swift
@@ -64,6 +64,13 @@ class PrefsWindow: NSWindow {
         center()
     }
 
+    func showGeneral() {
+        previousIdentifier = .none
+        toolbar?.selectedItemIdentifier = .general
+        clickToolbarItem(NSToolbarItem(itemIdentifier: .general))
+        show()
+    }
+
     override func close() {
         super.close()
         self.orderOut(NSApp)

--- a/HeliPort/Appearance/StatusBarIcon/StatusBarIconManager.swift
+++ b/HeliPort/Appearance/StatusBarIcon/StatusBarIconManager.swift
@@ -74,8 +74,11 @@ class StatusBarIcon {
         guard timer == nil else { return }
         tickIndex = 0
         tickDirection = 1
-        DispatchQueue.global(qos: .default).async {
-            self.timer = Timer.scheduledTimer(
+        DispatchQueue.main.async {
+            guard self.timer == nil else {
+                return
+            }
+            self.timer = Timer(
                 timeInterval: 0.3,
                 target: self,
                 selector: #selector(self.tick),
@@ -83,8 +86,7 @@ class StatusBarIcon {
                 repeats: true
             )
             self.timer?.fire()
-            RunLoop.current.add(self.timer!, forMode: .common)
-            RunLoop.current.run()
+            RunLoop.main.add(self.timer!, forMode: .common)
         }
     }
 

--- a/HeliPort/Appearance/StatusMenu/MenuItemView/WiFiMenuItemViewLegacy.swift
+++ b/HeliPort/Appearance/StatusMenu/MenuItemView/WiFiMenuItemViewLegacy.swift
@@ -101,7 +101,7 @@ class WifiMenuItemViewLegacy: SelectableMenuItemView, WifiMenuItemView {
 
     public var networkInfo: NetworkInfo {
         willSet(networkInfo) {
-            ssidLabel.stringValue = networkInfo.ssid
+            ssidLabel.stringValue = networkInfo.displaySSID
             layoutSubtreeIfNeeded()
         }
         didSet {

--- a/HeliPort/Appearance/StatusMenu/MenuItemView/WiFiMenuItemViewModern.swift
+++ b/HeliPort/Appearance/StatusMenu/MenuItemView/WiFiMenuItemViewModern.swift
@@ -117,7 +117,7 @@ class WifiMenuItemViewModern: SelectableMenuItemView, WifiMenuItemView {
 
     public var networkInfo: NetworkInfo {
         willSet(info) {
-            ssidLabel.stringValue = info.ssid
+            ssidLabel.stringValue = info.displaySSID
             layoutSubtreeIfNeeded()
         }
         didSet {

--- a/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
+++ b/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
@@ -357,6 +357,7 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
     struct StationInfo {
         var ssid: String?
         var rssiValue: Int = 0
+        var channelValue: Int = 0
         var ipAddr: String = .unavailable
         var routerAddr: String = .unavailable
         var internet: String = .unavailable
@@ -398,6 +399,7 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
         infoOut.isNetworkConnected = true
         infoOut.ssid = String(ssid: infoIn.ssid)
         infoOut.rssiValue = Int(infoIn.rssi)
+        infoOut.channelValue = Int(infoIn.channel)
 
         guard showAllOptions else { return infoOut }
 
@@ -457,7 +459,10 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
         if !wifiItemView.connected && info.isNetworkConnected {
             for index in self.headerLength ..< self.items.count {
                 if let view = self.items[index].view as? WifiMenuItemView,
-                   view.networkInfo.ssid == info.ssid {
+                   view.networkInfo.matchesAccessPoint(NetworkInfo(ssid: info.ssid ?? "",
+                                                                   rssi: info.rssiValue,
+                                                                   bssid: info.bssid,
+                                                                   channel: info.channelValue)) {
                     self.items[index].isHidden = true
                     self.items[index].isEnabled = false
                     break
@@ -472,9 +477,14 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
 
         isNetworkListEmpty = false
         if let staSSID = info.ssid, wifiItemView.networkInfo.ssid != staSSID {
-            wifiItemView.networkInfo = NetworkInfo(ssid: staSSID, rssi: info.rssiValue)
+            wifiItemView.networkInfo = NetworkInfo(ssid: staSSID,
+                                                   rssi: info.rssiValue,
+                                                   bssid: info.bssid,
+                                                   channel: info.channelValue)
         } else {
             wifiItemView.networkInfo.rssi = info.rssiValue
+            wifiItemView.networkInfo.channel = info.channelValue
+            wifiItemView.networkInfo.bssid = info.bssid
             wifiItemView.updateImages()
         }
     }
@@ -486,7 +496,7 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
         for info in infoList {
             var enabled = true
 
-            if let staInfo, staInfo.ssid == info.ssid {
+            if info.matchesAccessPoint(staInfo), let staInfo {
                 staInfo.auth.security = info.auth.security
                 (self.currentNetworkItem.view as? WifiMenuItemView)?.updateImages()
                 enabled = false

--- a/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
+++ b/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
@@ -320,7 +320,7 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
             alert.show()
         case .Legacy.openNetworkPrefs, .Modern.wifiSettings:
             preferenceWindow.close()
-            preferenceWindow.show()
+            preferenceWindow.showGeneral()
         case .launchLogin:
             LoginItemManager.setStatus(enabled: !LoginItemManager.isEnabled())
             isAutoLaunch = LoginItemManager.isEnabled()

--- a/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
+++ b/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
@@ -184,20 +184,16 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
         (self as? StatusMenuItems)?.setupMenu()
         getDeviceInfo()
 
-        DispatchQueue.global(qos: .default).async {
-            self.statusUpdateTimer = Timer.scheduledTimer(
-                timeInterval: self.statusUpdatePeriod,
-                target: self,
-                selector: #selector(self.updateStatus),
-                userInfo: nil,
-                repeats: true
-            )
+        statusUpdateTimer = Timer(
+            timeInterval: statusUpdatePeriod,
+            target: self,
+            selector: #selector(updateStatus),
+            userInfo: nil,
+            repeats: true
+        )
+        RunLoop.main.add(statusUpdateTimer!, forMode: .common)
 
-            self.statusUpdateTimer?.fire()
-            let currentRunLoop = RunLoop.current
-            currentRunLoop.add(self.statusUpdateTimer!, forMode: .common)
-            currentRunLoop.run()
-        }
+        updateStatus()
 
         NSApp.servicesProvider = self
     }
@@ -216,24 +212,22 @@ class StatusMenuBase: NSMenu, NSMenuDelegate {
     func menuWillOpen(_ menu: NSMenu) {
         showAllOptions = (NSApp.currentEvent?.modifierFlags.contains(.option)) ?? false
 
-        DispatchQueue.global(qos: .default).async {
-            self.updateStationItems()
-            self.networkListUpdateTimer = Timer.scheduledTimer(
-                timeInterval: self.networkListUpdatePeriod,
-                target: self,
-                selector: #selector(self.updateNetworkList),
-                userInfo: nil,
-                repeats: true
-            )
-            self.networkListUpdateTimer?.fire()
-            let currentRunLoop = RunLoop.current
-            currentRunLoop.add(self.networkListUpdateTimer!, forMode: .common)
-            currentRunLoop.run()
-        }
+        updateStationItems()
+        updateNetworkList()
+        networkListUpdateTimer?.invalidate()
+        networkListUpdateTimer = Timer(
+            timeInterval: networkListUpdatePeriod,
+            target: self,
+            selector: #selector(updateNetworkList),
+            userInfo: nil,
+            repeats: true
+        )
+        RunLoop.main.add(networkListUpdateTimer!, forMode: .common)
     }
 
     func menuDidClose(_ menu: NSMenu) {
         networkListUpdateTimer?.invalidate()
+        networkListUpdateTimer = nil
         (menu.highlightedItem?.view as? SelectableMenuItemView)?.isMouseOver = false
     }
 

--- a/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
+++ b/HeliPort/Appearance/StatusMenu/StatusMenuBase.swift
@@ -568,7 +568,7 @@ extension String {
         static let wifiOff = NSLocalizedString("Wi-Fi: Off")
         static let joinNetworks = NSLocalizedString("Join Other Network...")
         static let createNetwork = NSLocalizedString("Create Network...")
-        static let openNetworkPrefs = NSLocalizedString("Open Network Preferences...")
+        static let openNetworkPrefs = NSLocalizedString("Settings...")
         static let disconnectNet = NSLocalizedString("Disconnect from ")
     }
 

--- a/HeliPort/CredentialsManager.swift
+++ b/HeliPort/CredentialsManager.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 import KeychainAccess
+import Security
 
 final class CredentialsManager {
     static let instance: CredentialsManager = CredentialsManager()
@@ -34,6 +35,35 @@ final class CredentialsManager {
             return
         }
         storageCache.removeObject(forKey: ssid as NSString)
+    }
+
+    private func getStoredSSIDs() -> [String] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Bundle.main.bundleIdentifier!,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true
+        ]
+
+        if #available(macOS 10.11, *) {
+            query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIAllow
+        }
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            guard let items = result as? [[String: Any]] else {
+                return []
+            }
+            return items.compactMap { $0[kSecAttrAccount as String] as? String }
+        case errSecItemNotFound:
+            return []
+        default:
+            Log.error("Failed to enumerate saved networks: \(status)")
+            return []
+        }
     }
 
     func save(_ network: NetworkInfo) {
@@ -136,7 +166,7 @@ final class CredentialsManager {
     }
 
     func getSavedNetworks() -> [NetworkInfo] {
-        return (keychain.allKeys().compactMap { ssid in
+        return (getStoredSSIDs().compactMap { ssid in
             return getStorageFromSsid(ssid)
         } as [NetworkInfoStorageEntity]).filter { entity in
             entity.autoJoin && entity.version == NetworkInfoStorageEntity.CURRENT_VERSION
@@ -151,13 +181,13 @@ final class CredentialsManager {
         if let cached = ssidCache.object(forKey: ssidCacheKey) as? Set<String> {
             return cached
         }
-        let savedSSIDs = Set(keychain.allKeys())
+        let savedSSIDs = Set(getStoredSSIDs())
         ssidCache.setObject(savedSSIDs as NSSet, forKey: ssidCacheKey)
         return savedSSIDs
     }
 
     func getSavedNetworksEntity() -> [NetworkInfoStorageEntity] {
-        return (keychain.allKeys().compactMap { ssid in
+        return (getStoredSSIDs().compactMap { ssid in
             return getStorageFromSsid(ssid)
         } as [NetworkInfoStorageEntity]).filter { entity in
             entity.version == NetworkInfoStorageEntity.CURRENT_VERSION

--- a/HeliPort/CredentialsManager.swift
+++ b/HeliPort/CredentialsManager.swift
@@ -22,9 +22,18 @@ final class CredentialsManager {
     private let keychain: Keychain
     private let ssidCache: NSCache = NSCache<NSString, NSSet>()
     private let ssidCacheKey = NSString("savedSSIDs")
+    private let storageCache = NSCache<NSString, NSString>()
 
     private init() {
         keychain = Keychain(service: Bundle.main.bundleIdentifier!)
+    }
+
+    private func invalidateStorageCache(for ssid: String? = nil) {
+        guard let ssid else {
+            storageCache.removeAllObjects()
+            return
+        }
+        storageCache.removeObject(forKey: ssid as NSString)
     }
 
     func save(_ network: NetworkInfo) {
@@ -41,6 +50,7 @@ final class CredentialsManager {
 
         Log.debug("Saving password for network \(network.ssid)")
         try? keychain.comment(entityJson).set(networkAuthJson, key: network.keychainKey)
+        invalidateStorageCache(for: network.keychainKey)
     }
 
     func get(_ network: NetworkInfo) -> NetworkAuth? {
@@ -57,16 +67,28 @@ final class CredentialsManager {
     func remove(_ network: NetworkInfo) {
         Log.debug("Removing \(network.ssid) from keychain")
         try? keychain.remove(network.keychainKey)
+        ssidCache.removeObject(forKey: ssidCacheKey)
+        invalidateStorageCache(for: network.keychainKey)
     }
 
     func getStorageFromSsid(_ ssid: String) -> NetworkInfoStorageEntity? {
+        if let cached = storageCache.object(forKey: ssid as NSString),
+           let jsonData = (cached as String).data(using: .utf8) {
+            return try? JSONDecoder().decode(NetworkInfoStorageEntity.self, from: jsonData)
+        }
+
         guard let attributes = try? keychain.get(ssid, handler: {$0}),
             let json = attributes.comment,
             let jsonData = json.data(using: .utf8) else {
                 return nil
         }
 
-        return try? JSONDecoder().decode(NetworkInfoStorageEntity.self, from: jsonData)
+        guard let entity = try? JSONDecoder().decode(NetworkInfoStorageEntity.self, from: jsonData) else {
+            return nil
+        }
+
+        storageCache.setObject(json as NSString, forKey: ssid as NSString)
+        return entity
     }
 
     func getAuthFromSsid(_ ssid: String) -> NetworkAuth? {
@@ -93,6 +115,7 @@ final class CredentialsManager {
         }
 
         try? keychain.comment(entityJson).set(authJson, key: ssid)
+        invalidateStorageCache(for: ssid)
     }
 
     func setPriority(_ ssid: String, _ priority: Int) {
@@ -109,6 +132,7 @@ final class CredentialsManager {
         }
 
         try? keychain.comment(entityJson).set(authJson, key: ssid)
+        invalidateStorageCache(for: ssid)
     }
 
     func getSavedNetworks() -> [NetworkInfo] {

--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -124,7 +124,8 @@ final class NetworkManager {
                 let networkInfo = NetworkInfo(
                     ssid: ssid,
                     rssi: Int(network.rssi),
-                    bssid: formatBSSID(network.bssid)
+                    bssid: formatBSSID(network.bssid),
+                    channel: Int(network.channel)
                 )
                 networkInfo.auth.security = getSecurityType(network)
                 result.append(networkInfo)
@@ -160,6 +161,35 @@ final class NetworkManager {
                       bssid.3,
                       bssid.4,
                       bssid.5)
+    }
+
+    static func getCurrentNetworkInfo() -> CurrentNetworkInfo {
+        var infoOut = CurrentNetworkInfo()
+        var infoIn = station_info_t()
+
+        guard get_station_info(&infoIn) == KERN_SUCCESS else {
+            return infoOut
+        }
+
+        infoOut.isConnected = true
+        infoOut.ssid = String(ssid: infoIn.ssid)
+        infoOut.bssid = formatBSSID(infoIn.bssid)
+        infoOut.channel = "\(infoIn.channel) (\(infoIn.channel <= 14 ? 2.4 : 5) GHz, \(infoIn.band_width) MHz)"
+        infoOut.rssi = "\(infoIn.rssi) dBm"
+        infoOut.noise = "\(infoIn.noise) dBm"
+        infoOut.txRate = "\(infoIn.rate) Mbps"
+        infoOut.phyMode = infoIn.op_mode.description
+        infoOut.internet = isReachable() ? NSLocalizedString("Reachable") : NSLocalizedString("Unreachable")
+
+        var platformInfo = platform_info_t()
+        if get_platform_info(&platformInfo) {
+            let bsd = String(cCharArray: platformInfo.device_info_str)
+            infoOut.interfaceName = bsd
+            infoOut.ipAddress = getLocalAddress(bsd: bsd) ?? NSLocalizedString("Unknown")
+            infoOut.router = getRouterAddress(bsd: bsd) ?? NSLocalizedString("Unknown")
+        }
+
+        return infoOut
     }
 
     static func scanSavedNetworks() {

--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -94,7 +94,7 @@ final class NetworkManager {
             let savedSSIDs = CredentialsManager.instance.getSavedNetworkSSIDs()
             scanNetwork { result in
                 let known = result.filter { savedSSIDs.contains($0.ssid) }
-                let other = result.subtracting(known)
+                let other = result.filter { !savedSSIDs.contains($0.ssid) }
 
                 DispatchQueue.main.async {
                     callback(known.sorted(by: areInIncreasingOrder),
@@ -104,12 +104,12 @@ final class NetworkManager {
         }
     }
 
-    private static func scanNetwork(callback: @escaping (_ networkInfoList: Set<NetworkInfo>) -> Void) {
+    private static func scanNetwork(callback: @escaping (_ networkInfoList: [NetworkInfo]) -> Void) {
         DispatchQueue.global(qos: .background).async {
             var list = network_info_list_t()
             get_network_list(&list)
 
-            var result = Set<NetworkInfo>()
+            var result = [NetworkInfo]()
             let networks = Mirror(reflecting: list.networks).children.map({ $0.value }).prefix(Int(list.count))
 
             for element in networks {
@@ -123,16 +123,43 @@ final class NetworkManager {
 
                 let networkInfo = NetworkInfo(
                     ssid: ssid,
-                    rssi: Int(network.rssi)
+                    rssi: Int(network.rssi),
+                    bssid: formatBSSID(network.bssid)
                 )
                 networkInfo.auth.security = getSecurityType(network)
-                result.insert(networkInfo)
+                result.append(networkInfo)
             }
 
             DispatchQueue.main.async {
-                callback(result)
+                callback(filterDuplicateSSIDsIfNeeded(result))
             }
         }
+    }
+
+    private static func filterDuplicateSSIDsIfNeeded(_ networks: [NetworkInfo]) -> [NetworkInfo] {
+        guard !UserDefaults.standard.bool(forKey: .DefaultsKey.showDuplicateSSIDsByBSSID) else {
+            return networks
+        }
+
+        var strongestNetworkBySSID = [String: NetworkInfo]()
+        networks.forEach { network in
+            if let savedNetwork = strongestNetworkBySSID[network.ssid],
+               savedNetwork.rssi >= network.rssi {
+                return
+            }
+            strongestNetworkBySSID[network.ssid] = network
+        }
+        return Array(strongestNetworkBySSID.values)
+    }
+
+    private static func formatBSSID(_ bssid: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) -> String {
+        return String(format: "%02x:%02x:%02x:%02x:%02x:%02x",
+                      bssid.0,
+                      bssid.1,
+                      bssid.2,
+                      bssid.3,
+                      bssid.4,
+                      bssid.5)
     }
 
     static func scanSavedNetworks() {

--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -131,8 +131,9 @@ final class NetworkManager {
                 result.append(networkInfo)
             }
 
+            let filteredResult = filterDuplicateSSIDsIfNeeded(result)
             DispatchQueue.main.async {
-                callback(filterDuplicateSSIDsIfNeeded(result))
+                callback(filteredResult)
             }
         }
     }
@@ -142,15 +143,50 @@ final class NetworkManager {
             return networks
         }
 
+        let connectedAccessPoint = getConnectedAccessPoint()
         var strongestNetworkBySSID = [String: NetworkInfo]()
         networks.forEach { network in
-            if let savedNetwork = strongestNetworkBySSID[network.ssid],
-               savedNetwork.rssi >= network.rssi {
+            if let connectedAccessPoint,
+               network.ssid == connectedAccessPoint.ssid,
+               network.matchesAccessPoint(connectedAccessPoint) {
+                strongestNetworkBySSID[network.ssid] = network
                 return
             }
+
+            if let savedNetwork = strongestNetworkBySSID[network.ssid] {
+                if let connectedAccessPoint,
+                   savedNetwork.ssid == connectedAccessPoint.ssid,
+                   savedNetwork.matchesAccessPoint(connectedAccessPoint) {
+                    return
+                }
+
+                if savedNetwork.rssi >= network.rssi {
+                    return
+                }
+            }
+
             strongestNetworkBySSID[network.ssid] = network
         }
         return Array(strongestNetworkBySSID.values)
+    }
+
+    private static func getConnectedAccessPoint() -> NetworkInfo? {
+        var info = station_info_t()
+        guard get_station_info(&info) == KERN_SUCCESS else {
+            return nil
+        }
+
+        let ssid = String(ssid: info.ssid)
+        guard !ssid.isEmpty else {
+            return nil
+        }
+
+        return NetworkInfo(
+            ssid: ssid,
+            rssi: Int(info.rssi),
+            bssid: formatBSSID(info.bssid),
+            channel: Int(info.channel)
+        )
     }
 
     private static func formatBSSID(_ bssid: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) -> String {

--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -25,6 +25,7 @@ final class NetworkManager {
         ITL80211_SECURITY_WPA2_PERSONAL,
         ITL80211_SECURITY_PERSONAL
     ]
+    private static var autoJoinTimer: DispatchSourceTimer?
 
     static func connect(networkInfo: NetworkInfo, saveNetwork: Bool = false,
                         _ callback: ((_ result: Bool) -> Void)? = nil) {
@@ -141,22 +142,23 @@ final class NetworkManager {
                 Log.debug("No network saved for auto join")
                 return
             }
-            let scanTimer: Timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { timer in
+            autoJoinTimer?.cancel()
+            let scanTimer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .background))
+            autoJoinTimer = scanTimer
+            scanTimer.schedule(deadline: .now(), repeating: .seconds(5))
+            scanTimer.setEventHandler {
                 NetworkManager.scanNetwork { networkList in
                     let targetNetworks = savedNetworks.filter { networkList.contains($0) }
-                    if targetNetworks.count > 0 {
-                        // This will stop the timer completely
-                        timer.invalidate()
-                        Log.debug("Auto join timer stopped")
-                        connectSavedNetworks(networks: targetNetworks)
+                    guard targetNetworks.count > 0 else {
+                        return
                     }
+                    NetworkManager.autoJoinTimer?.cancel()
+                    NetworkManager.autoJoinTimer = nil
+                    Log.debug("Auto join timer stopped")
+                    connectSavedNetworks(networks: targetNetworks)
                 }
             }
-            // Start executing code inside the timer immediately
-            scanTimer.fire()
-            let currentRunLoop = RunLoop.current
-            currentRunLoop.add(scanTimer, forMode: .common)
-            currentRunLoop.run()
+            scanTimer.resume()
         }
     }
 

--- a/HeliPort/Supporting files/NetworkManager+Data.swift
+++ b/HeliPort/Supporting files/NetworkManager+Data.swift
@@ -18,12 +18,22 @@ import Foundation
 final class NetworkInfo: Codable {
     let ssid: String
     var rssi: Int
+    var bssid: String
 
     var auth = NetworkAuth()
 
-    init (ssid: String, rssi: Int = 0) {
+    init (ssid: String, rssi: Int = 0, bssid: String = "") {
         self.ssid = ssid
         self.rssi = rssi
+        self.bssid = bssid
+    }
+
+    var displaySSID: String {
+        guard UserDefaults.standard.bool(forKey: .DefaultsKey.showDuplicateSSIDsByBSSID),
+              !bssid.isEmpty else {
+            return ssid
+        }
+        return "\(ssid) (\(bssid))"
     }
 }
 

--- a/HeliPort/Supporting files/NetworkManager+Data.swift
+++ b/HeliPort/Supporting files/NetworkManager+Data.swift
@@ -19,21 +19,45 @@ final class NetworkInfo: Codable {
     let ssid: String
     var rssi: Int
     var bssid: String
+    var channel: Int
 
     var auth = NetworkAuth()
 
-    init (ssid: String, rssi: Int = 0, bssid: String = "") {
+    init (ssid: String, rssi: Int = 0, bssid: String = "", channel: Int = 0) {
         self.ssid = ssid
         self.rssi = rssi
         self.bssid = bssid
+        self.channel = channel
     }
 
     var displaySSID: String {
-        guard UserDefaults.standard.bool(forKey: .DefaultsKey.showDuplicateSSIDsByBSSID),
-              !bssid.isEmpty else {
+        var details = [String]()
+        if !bandDescription.isEmpty {
+            details.append(bandDescription)
+        }
+
+        if UserDefaults.standard.bool(forKey: .DefaultsKey.showDuplicateSSIDsByBSSID),
+           !bssid.isEmpty {
+            details.append(bssid)
+        }
+
+        guard !details.isEmpty else {
             return ssid
         }
-        return "\(ssid) (\(bssid))"
+        return "\(ssid) (\(details.joined(separator: ", ")))"
+    }
+
+    var bandDescription: String {
+        guard channel > 0 else { return "" }
+        return channel <= 14 ? "2.4 GHz" : "5 GHz"
+    }
+
+    func matchesAccessPoint(_ other: NetworkInfo?) -> Bool {
+        guard let other else { return false }
+        if !bssid.isEmpty, !other.bssid.isEmpty {
+            return bssid == other.bssid
+        }
+        return ssid == other.ssid
     }
 }
 
@@ -68,4 +92,26 @@ final class NetworkInfoStorageEntity: Codable {
         self.autoJoin = autoJoin
         self.order = order
     }
+}
+
+struct CurrentNetworkInfo {
+    var interfaceName: String = .unavailable
+    var ssid: String = .unavailable
+    var bssid: String = .unavailable
+    var channel: String = .unavailable
+    var rssi: String = .unavailable
+    var noise: String = .unavailable
+    var txRate: String = .unavailable
+    var phyMode: String = .unavailable
+    var ipAddress: String = .unavailable
+    var router: String = .unavailable
+    var internet: String = .unavailable
+    var isConnected = false
+}
+
+private extension String {
+    static let unavailable = NSLocalizedString("Unavailable")
+    static let unknown = NSLocalizedString("Unknown")
+    static let reachable = NSLocalizedString("Reachable")
+    static let unreachable = NSLocalizedString("Unreachable")
 }

--- a/HeliPort/Supporting files/String+Extensions.swift
+++ b/HeliPort/Supporting files/String+Extensions.swift
@@ -18,6 +18,7 @@ import Foundation
 public extension String {
     enum DefaultsKey {
         static let legacyUI = "legacyUIEnabled"
+        static let showDuplicateSSIDsByBSSID = "showDuplicateSSIDsByBSSID"
     }
 
     init<T>(ssid: T) {


### PR DESCRIPTION
## What changed
- ports the memory-footprint fixes onto the upstream modern UI branch
- adds a GitHub Actions workflow that builds an unsigned HeliPort.app artifact
- keeps the app runnable from local build paths in Debug builds
- restores Settings access from legacy mode
- adds an advanced option to show duplicate same-SSID APs separately by BSSID
- shows Wi-Fi band details in the scan list and adds a Current settings tab with live connection details
- fixes collapsed same-SSID lists so the connected AP entry prefers the actual connected BSSID/channel
- adds an App settings tab with a Quit action and keeps all settings tabs visible by widening the preferences window

## Why
This branch combines the modern UI work with a set of stability and diagnostics changes aimed at Hackintosh users running itlwm + HeliPort. The main goals were to reduce background timer/run-loop overhead, make AP selection and current connection state easier to inspect, and remove a few UX traps in the preferences window.

## User impact
- lower idle memory pressure from the earlier timer model
- better visibility into 2.4 GHz vs 5 GHz APs, BSSIDs, and current link state
- easier recovery from legacy mode and direct access to app exit from Settings
- CI artifacts available from GitHub Actions builds

## Root cause
The incorrect band label in collapsed network lists came from choosing the strongest scan result for a shared SSID even when the machine was connected to a different AP on the same SSID. The settings toolbar issue came from the window being narrow enough for the fourth tab to fall into toolbar overflow.

## Validation
- xcodebuild -project HeliPort.xcodeproj -scheme HeliPort -configuration Debug -derivedDataPath /tmp/HeliPort-modern-build CODE_SIGNING_ALLOWED=NO build
- git worktree clean before PR creation
